### PR TITLE
Updating to use newer Django version and new cpp libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,32 @@ It is also possible to use this script to run avaCapture and allow it to update 
 
     ./run_node_loop.sh &
 
+### Ubuntu 22.10  
+
+Removing `cmake_check_build_system` from the `all` Makefile directive.
+
+Next install the Ximea SDK from http://www.ximea.com.
+
+To compile, first git clone this project. Make sure these packages are installed:
+
+    sudo apt-get install cmake git
+    sudo apt-get install libboost-all-dev rapidjson-dev libavcodec-dev libavformat-dev libswscale-dev python2.7-dev
+
+Then follow these steps to compile:
+
+    cd capture-node
+    cmake .
+    cd thirdparty/lz4/tmp/
+    sed -i 's/master/dev/g' *
+    grep -rnw '.' -e 'master'
+    make
+
+And finally run the node with this command. The server address corresponds to the machine running the Ava Website Backend.
+
+    ./avaCapture --folder capture_store --server 127.0.0.1 --port 8000
+
+
+
 ## Ava Website Frontend
 
 The website is a single-page Angular application. It is compiled into a few static files that are served by the webserver (or the Django backend for development). The source code is compiled using Node.js.
@@ -85,6 +111,14 @@ This will generate files in /dist-prod. These files should be copied to the prod
 
 The Backend can run on any web server (eg. nginx). For development purposes, it can also run directly from the Django server in Windows or other supported OS. It is possible to create a Python environment, install the libraries from requirements.txt and then run the django server with:
 
+    conda create --name avapy310 python=3.10
+    conda activate avapy310
+    pip install -r requirements.txt
+    mkdir dev-database
+    mkdir dev-thumb
+    python create_db.py
+    mv sqlite3.db dev-database/
+    pip install pytz
     python manage.py migrate
     python manage.py initialsetup
     python manage.py runserver 0.0.0.0:80

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Then follow these steps to compile:
 
 And finally run the node with this command. The server address corresponds to the machine running the Ava Website Backend.
 
+    sudo tee /sys/module/usbcore/parameters/usbfs_memory_mb >/dev/null <<<0
     ./avaCapture --folder capture_store --server 127.0.0.1 --port 8000
 
 

--- a/capture-node/CMakeLists.txt
+++ b/capture-node/CMakeLists.txt
@@ -17,7 +17,7 @@ include(ExternalProject)
 file(GLOB SOURCES "source/*.cpp")
 
 #Include OpenCV
-find_package(OpenCV 3.2.0 REQUIRED)
+find_package(OpenCV 4.6.0 REQUIRED)
 include_directories(${OpenCV_INCLUDE_DIRS})
 
 find_package(OpenSSL REQUIRED)
@@ -29,7 +29,7 @@ include_directories(${PYTHON_INCLUDE_DIRS})
 set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.58.0 REQUIRED COMPONENTS thread filesystem program_options)
+find_package(Boost 1.58.0 REQUIRED COMPONENTS thread filesystem program_options chrono)
 include_directories(${Boost_INCLUDE_DIRS})
 
 # Portaudio

--- a/capture-node/source/cameras.hpp
+++ b/capture-node/source/cameras.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <iostream>
 #include <string>
 #include <map>
 #include <deque>
@@ -120,9 +121,11 @@ public:
 
 	virtual void stop_capture()
 	{
+		std::cout << "STATUS> Stop capture" << std::endl;
 		// Stop Capturing Frames
 		m_effective_fps = 0;
 		m_capturing = false;
+		m_recording = false;
 	}
 
 	virtual bool is_valid() const { return true; } // If a camera becomes invalid it will be removed
@@ -130,6 +133,7 @@ public:
 
 	virtual void start_recording(const std::vector<std::string>& folders, bool wait_for_trigger, int nb_frames=-1);
 	virtual void stop_recording();
+	virtual void stop_recording(std::vector<std::string> folders);
 
 	virtual bool set_bitdepth(int bitdepth) { return false; }
 

--- a/capture-node/source/capturenode.hpp
+++ b/capture-node/source/capturenode.hpp
@@ -59,6 +59,7 @@ public:
 	void record_image_sequence(int frame_count); // Execute all steps to capture a single image
 	void start_recording_all(); // Execute all steps to start recording
 	void stop_recording_all();
+	void stop_recording_all(std::vector<std::string> folders);
 
 	shared_json_doc get_last_summary() const { return m_last_summary;  }
 

--- a/capture-node/source/nodehttpserver.cpp
+++ b/capture-node/source/nodehttpserver.cpp
@@ -462,6 +462,9 @@ std::string NodeHttpServer::handleRequest(std::shared_ptr<Session> session)
 		if (paths.size()>0 && paths[0] == "download")
 			return getDirectDownload(session);
 
+		if (paths.size() == 1 && paths[0] == "cameras")
+			return getCamerasPage(session);
+
 		if (paths.size() > 0 && paths[0] == "close_node")
 		{
 			m_node->shutdown();

--- a/capture-node/ximea_test/CMakeLists.txt
+++ b/capture-node/ximea_test/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 2.8)
+project( ximeaTest )
+find_package( OpenCV REQUIRED )
+include_directories( "m3api/xiApi.h" ${OpenCV_INCLUDE_DIRS} )
+add_executable( ximeaTest ximeaTest.cpp )
+target_link_libraries( ximeaTest ${OpenCV_LIBS} "m3api" )

--- a/capture-node/ximea_test/ximeaTest.cpp
+++ b/capture-node/ximea_test/ximeaTest.cpp
@@ -10,6 +10,10 @@
 #include <memory.h>
 
 #include <string>
+#include <vector>
+
+#include <opencv2/opencv.hpp>
+using namespace cv;
 
 #define HandleResult(res,place) if (res!=XI_OK) {printf("Error after %s (%d)\n",place,res); exit(1);}
 
@@ -57,7 +61,7 @@ int captureSomeFrames(HANDLE xiH)
 
 	double last_ts = 0.0;
 
-#define EXPECTED_IMAGES 20
+#define EXPECTED_IMAGES 1
 	for (int images = 0; images < EXPECTED_IMAGES; images++)
 	{
 		XI_IMG image;
@@ -67,6 +71,17 @@ int captureSomeFrames(HANDLE xiH)
 		// getting image from camera
 		stat = xiGetImage(xiH, 5000, &image);
 		HandleResult(stat, "xiGetImage");
+
+		const char *fileName = "example.png";
+		int width = 1024;
+		int height = 1024;
+		int byte_per_pixel = 1;
+		int max_pixel_value = 255;
+		Mat img_raw = Mat(height, width, CV_8UC1, image.bp, cv::Mat::AUTO_STEP);
+		std::vector<int> compression_params;
+		compression_params.push_back(IMWRITE_PNG_COMPRESSION);
+		compression_params.push_back(0);
+		imwrite(fileName, img_raw, compression_params);
 
 		double ts = image.tsSec + image.tsUSec / 1000000.0;
 		unsigned char pixel = *(unsigned char*)image.bp;
@@ -148,7 +163,7 @@ int _tmain(int argc, char* argv[])
 	#define EXPECTED_C2_VERSION "02.04"
 	#define EXPECTED_XML_VERSION "02.04.01"
 #else
-	#define EXPECTED_API_VERSION "V4.15.04.00"
+	#define EXPECTED_API_VERSION "V4.27.03.00"
 	#define EXPECTED_DRV_VERSION "0"
 	#define EXPECTED_F1_VERSION "01.18"
 	#define EXPECTED_C1_VERSION "04.22"

--- a/capture-node/ximea_test/ximeaTest.cpp
+++ b/capture-node/ximea_test/ximeaTest.cpp
@@ -72,7 +72,9 @@ int captureSomeFrames(HANDLE xiH)
 		stat = xiGetImage(xiH, 5000, &image);
 		HandleResult(stat, "xiGetImage");
 
-		const char *fileName = "example.png";
+		//const char *fileName = "example.png";
+		char fileName[120];
+		sprintf(fileName, "ximeaTest-%ld.png", time(0));
 		int width = 1024;
 		int height = 1024;
 		int byte_per_pixel = 1;
@@ -213,8 +215,9 @@ int _tmain(int argc, char* argv[])
 	set_param_int(xiH, XI_PRM_GPI_MODE, XI_GPI_TRIGGER);
 	set_param_int(xiH, XI_PRM_TRG_SOURCE, XI_TRG_EDGE_RISING);
 	set_param_int(xiH, XI_PRM_BPC, XI_ON);
-	//set_param_int(xiH, XI_PRM_IMAGE_BLACK_LEVEL, 0);
-	set_param_int(xiH, XI_PRM_IMAGE_DATA_FORMAT, XI_RAW8);
+	set_param_int(xiH, XI_PRM_IMAGE_BLACK_LEVEL, 0);
+	//set_param_int(xiH, XI_PRM_IMAGE_DATA_FORMAT, XI_RAW8);
+	set_param_int(xiH, XI_PRM_IMAGE_DATA_FORMAT, XI_RGB24);
 
 	int m_max_bandwidth = get_param_int(xiH, XI_PRM_AVAILABLE_BANDWIDTH);
 	printf("Max Bandwdth: %d Mbit/s\n", m_max_bandwidth);

--- a/capture-node/ximea_test/ximeaTest.py
+++ b/capture-node/ximea_test/ximeaTest.py
@@ -1,0 +1,62 @@
+from ximea import xiapi
+import cv2
+
+image_file_name = 'image-94' 
+image_file_type = '.png'
+
+#create instance for first connected camera
+cam = xiapi.Camera()
+
+#start communication
+#to open specific device, use:
+#cam.open_device_by_SN('41305651')
+#(open by serial number)
+print('Opening first camera...')
+cam.open_device()
+
+#settings
+cam.set_exposure(20000)
+print('Exposure was set to %i us' %cam.get_exposure())
+cam.set_imgdataformat('XI_MONO8')
+print('Image data format set to %s' % cam.get_imgdataformat())
+
+#create instance of Image to store image data and metadata
+img = xiapi.Image()
+print(dir(img))
+
+
+#start data acquisition
+print('Starting data acquisition...')
+cam.start_acquisition()
+
+for i in range(1):
+    #get data and pass them from camera to img
+    cam.get_image(img)
+
+    #get raw data from camera
+    #for Python2.x function returns string
+    #for Python3.x function returns bytes
+    #data_raw = img.get_image_data_raw()
+    data_numpy = img.get_image_data_numpy()
+
+    #transform data to list
+    #data = list(data_raw)
+
+    #print image data and metadata
+    #print('Image number: ' + str(i))
+    #print('Image width (pixels):  ' + str(img.width))
+    #print('Image height (pixels): ' + str(img.height))
+    #print('First 10 pixels: ' + str(data[:10]))
+
+    print('Saving image...')
+    cv2.imwrite((image_file_name + image_file_type), data_numpy)
+    print('\n')    
+
+#stop data acquisition
+print('Stopping acquisition...')
+cam.stop_acquisition()
+
+#stop communication
+cam.close_device()
+
+print('Done.')

--- a/website-backend/ava/create_db.py
+++ b/website-backend/ava/create_db.py
@@ -1,0 +1,2 @@
+import sqlite3
+con = sqlite3.connect("sqlite3.db")

--- a/website-backend/requirements.txt
+++ b/website-backend/requirements.txt
@@ -1,6 +1,6 @@
 ansi2html
 boto3
-Django==2.2.27
+Django==3.2.15
 django-gravatar2
 django-model-utils
 django-prometheus

--- a/website-frontend/package.json
+++ b/website-frontend/package.json
@@ -22,31 +22,21 @@
     "@angular/platform-browser": "~6.1.10",
     "@angular/platform-browser-dynamic": "~6.1.10",
     "@angular/router": "~6.1.10",
-
     "angular-in-memory-web-api": "~0.6.1",
     "core-js": "^2.5.7",
     "rxjs": "6.3.3",
     "zone.js": "0.8.26",
-
     "@auth0/angular-jwt": "2.1.0",
-
     "font-awesome": "4.7.0"
-
   },
   "devDependencies": {
-
     "@types/node": "10.17.27",
-
     "typescript": "~3.1.3",
-
     "rimraf": "^2.6.2",
     "node-sass": "4.14.1",
-
     "jquery": "3.5.0",
-
     "ajv": "^6.5.4",
-
-    "awesome-typescript-loader" : "5.2.1",
+    "awesome-typescript-loader": "5.2.1",
     "angular2-template-loader": "^0.6.2",
     "css-loader": "^1.0.0",
     "file-loader": "^2.0.0",
@@ -57,17 +47,13 @@
     "sass-loader": "^7.1.0",
     "script-loader": "0.7.2",
     "font-awesome-sass-loader": "2.0.1",
-
     "html-webpack-plugin": "^3.2.0",
     "compression-webpack-plugin": "2.0.0",
-
     "webpack": "4.22.0",
     "webpack-cli": "3.1.2",
     "webpack-merge": "^4.1.4",
-
     "reflect-metadata": "0.1.12",
     "angular2-websocket": "0.9.7"
-
   },
   "repository": {}
 }


### PR DESCRIPTION
Bumps Django to 3.2.15 and uses OpenCV version 4.6.0. Updates capture-node/source/video_writer_avi.cpp to work with a newer ffmpeg library. Requires Boost component `chrono`.